### PR TITLE
Declare text_chars before assignment

### DIFF
--- a/lib/FilterHTML.js
+++ b/lib/FilterHTML.js
@@ -267,7 +267,7 @@ var FilterHTML = (function() {
    
    HTMLFilter.prototype.filter = function(html) {
       var tags, i, tag_text, tag_output;
-      var is_script_processed, is_script_escaped;
+      var is_script_processed, is_script_escaped, text_chars;
 
       this.row = 0;
       this.line = 0;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "David Collien",
   "name": "filterhtml",
   "description": "FilterHTML: A whitelisting HTML filter for Python and JavaScript",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "repository": {
     "url": "https://github.com/dcollien/FilterHTML"
   },

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
    name='FilterHTML',
-   version='0.6.0',
+   version='0.6.1',
    py_modules=['FilterHTML'],
    author='David Collien',
    author_email='me@dcollien.com',


### PR DESCRIPTION
Hey @dcollien,

We've recently switched from Browserify to Webpack and encountered a problem with the bundle.
I've noticed that one of your variables is being used without being declared and our current build tools did not expect to encounter it.

Could you have a look if you are fine with the changes? Looks like it was not there by accident but I might be wrong.

<img width="822" alt="ReferenceError" src="https://user-images.githubusercontent.com/12460870/58324006-84486880-7e1d-11e9-9099-93621d685d34.png">
