### PR TITLE
Fix the `self` is undefined error on `FilterHTML.js:669:22`.

### DIFF
--- a/lib/FilterHTML.js
+++ b/lib/FilterHTML.js
@@ -666,7 +666,7 @@ var FilterHTML = (function() {
       } else if (num_spaces === 0 && this.is_valid_unquoted_attr_char(this.curr_char)) {
          value += this.curr_char;
          while (this.is_valid_unquoted_attr_char(this.next())) {
-            value += self.curr_char;
+            value += this.curr_char;
          }
       }
 


### PR DESCRIPTION
A [reference to `self` was added](https://github.com/dcollien/FilterHTML/commit/e5dff92cbd99e1df472af37504b13062872355e8#diff-6de51f240bde33467eedde2778d765574864195f8fd0b598273543385bf01427R663) in v0.6 to `FilterHTML.js`.

This variable is not defined in the JS version, though it is in the Python version. Presumably an accidental copy/paste error.

This PR is updating that reference to `this`, which it seems like it should be based on the code around it.